### PR TITLE
fix: shadcnUI missing global style import on layout

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,7 @@ import { SpeedInsights } from "@vercel/speed-insights/next";
 import type { Metadata } from "next";
 import { Viewport } from "next";
 import { Roboto as FontSans } from "next/font/google";
+import "@/styles/globals.css";
 
 const fontSans = FontSans({
 	weight: ["400", "700"],


### PR DESCRIPTION
ShadcnUI components are unstyled without importing the global styles